### PR TITLE
feat: add support for writing new directories in the `writeFiles` action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "chatgpt-cli",
+  "name": "chisel",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "chatgpt-cli",
+      "name": "chisel",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/src/write-files.ts
+++ b/src/write-files.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "fs";
+import { writeFileSync, existsSync, mkdirSync } from "fs";
 import path from "path";
 
 export const writeFilesSpec = {
@@ -43,6 +43,13 @@ export function writeFiles(
                 "One of the paths is outside the directory: " + fullPath
             );
         }
+
+        if (!existsSync(fullPath)) {
+            const directory = path.dirname(fullPath);
+
+            mkdirSync(directory, { recursive: true });
+        }
+
         writeFileSync(fullPath, contentsArray[i]);
     }
 }


### PR DESCRIPTION
Had a play, wanted to get a TDD loop going but Chisel had trouble with new files in new directories -- exits with a `ENOENT` error for writing to files in new directories.

This allows new directories to be written to as long as they're in the allowed path, writing new files is already supported with the `writeFileSync` usage.

Figured it was more intuitive to include this in write files to avoid too much planning (e.g. create directory first then write file).